### PR TITLE
植木鉢・額縁の破壊等の操作を鯖民が出来ないように

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Permission
 
-- `azisabalobby-allow-flower-pot`
+- `azisabalobby.allow-flower-pot`
   - Permissions related to the destruction of flowerpots.
   - default: `op`
-- `azisabalobby-allow-picture-frame`
+- `azisabalobby.allow-picture-frame`
   - Permissions related to the destruction of picture frames.
   - default: `op`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Permission
 
-- `allow-interact-flower-pot`
+- `azisabalobby.allow-interact-flower-pot`
   - Permissions related to the destruction of flowerpots.
   - default: `op`
 - `azisabalobby.allow-destroy-painting`

--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@
 - `azisabalobby.allow-picture-frame`
   - Permissions related to the destruction of picture frames.
   - default: `op`
+- `azisabalobby.allow-flower-pot`
+  - Permissions related to the destruction of flowerpots.
+  - default: `op`
+- `azisabalobby.allow-picture-frame`
+  - Permissions related to the destruction of picture frames.
+  - default: `op`
+- `azisabalobby.allow-creative-mode`
+  - Whether the player is allowed to be in creative mode.
+  - default: `op`
+- `azisabalobby.allow-survival-mode`
+  - Whether the player is allowed to be in survival mode.
+  - default: `op`
+- `azisabalobby.allow-spectator-mode`
+  - Whether the player is allowed to be in spectator mode.
+  - default: `op`
+- `azisabalobby.allow-flight`
+  - Whether the player is allowed to fly.
+  - default: `op`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# AzisabaLobby
+
+## Permission
+
+- `azisabalobby-allow-flower-pot`
+  - Permissions related to the destruction of flowerpots.
+  - default: `op`
+- `azisabalobby-allow-picture-frame`
+  - Permissions related to the destruction of picture frames.
+  - default: `op`

--- a/README.md
+++ b/README.md
@@ -2,16 +2,10 @@
 
 ## Permission
 
-- `azisabalobby.allow-flower-pot`
+- `allow-interact-flower-pot`
   - Permissions related to the destruction of flowerpots.
   - default: `op`
-- `azisabalobby.allow-picture-frame`
-  - Permissions related to the destruction of picture frames.
-  - default: `op`
-- `azisabalobby.allow-flower-pot`
-  - Permissions related to the destruction of flowerpots.
-  - default: `op`
-- `azisabalobby.allow-picture-frame`
+- `azisabalobby.allow-destroy-painting`
   - Permissions related to the destruction of picture frames.
   - default: `op`
 - `azisabalobby.allow-creative-mode`

--- a/src/main/java/net/azisaba/lobby/AzisabaLobby.java
+++ b/src/main/java/net/azisaba/lobby/AzisabaLobby.java
@@ -1,7 +1,6 @@
 package net.azisaba.lobby;
 
-import net.azisaba.lobby.listeners.CheckJoinListener;
-import net.azisaba.lobby.listeners.VoidToSpawnListener;
+import net.azisaba.lobby.listeners.*;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -11,6 +10,8 @@ public class AzisabaLobby extends JavaPlugin {
     getConfig().options().copyDefaults();
     Bukkit.getPluginManager().registerEvents(new VoidToSpawnListener(this), this);
     Bukkit.getPluginManager().registerEvents(new CheckJoinListener(), this);
+    Bukkit.getPluginManager().registerEvents(new FlowerPotProtectionListener(), this);
+    Bukkit.getPluginManager().registerEvents(new HangingProtectionListener(), this);
     Bukkit.getLogger().info(getName() + " enabled.");
   }
 

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -10,7 +10,7 @@ public class FlowerPotProtectionListener implements Listener {
     @EventHandler
     public void onPot(PlayerInteractEvent e) {
         Player player = e.getPlayer();
-        if(player.hasPermission("azisabalobby.allow-flower-pot")) return;
+        if(player.hasPermission("allow-interact-flower-pot")) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -1,5 +1,6 @@
 package net.azisaba.lobby.listeners;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +15,9 @@ public class FlowerPotProtectionListener implements Listener {
         ItemStack item = e.getItem();
         if(player.hasPermission("azisabalobby.allow-interact-flower-pot")) return;
         if(item != null) {
-            e.setCancelled(true);
+            if(item.getType() == Material.FLOWER_POT) {
+                e.setCancelled(true);
+            }
         }
     }
 }

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -4,13 +4,17 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
 
 public class FlowerPotProtectionListener implements Listener {
 
     @EventHandler
     public void onPot(PlayerInteractEvent e) {
         Player player = e.getPlayer();
+        ItemStack item = e.getItem();
         if(player.hasPermission("azisabalobby.allow-interact-flower-pot")) return;
-        e.setCancelled(true);
+        if(item != null) {
+            e.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -1,23 +1,21 @@
 package net.azisaba.lobby.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.ItemStack;
 
 public class FlowerPotProtectionListener implements Listener {
 
     @EventHandler
     public void onPot(PlayerInteractEvent e) {
         Player player = e.getPlayer();
-        ItemStack item = e.getItem();
+        Block block = e.getClickedBlock();
         if(player.hasPermission("azisabalobby.allow-interact-flower-pot")) return;
-        if(item != null) {
-            if(item.getType() == Material.FLOWER_POT) {
-                e.setCancelled(true);
-            }
+        if(block != null && block.getType() == Material.FLOWER_POT) {
+            e.setCancelled(true);
         }
     }
 }

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -10,7 +10,7 @@ public class FlowerPotProtectionListener implements Listener {
     @EventHandler
     public void onPot(PlayerInteractEvent e) {
         Player player = e.getPlayer();
-        if(player.hasPermission("allow-interact-flower-pot")) return;
+        if(player.hasPermission("azisabalobby.allow-interact-flower-pot")) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/FlowerPotProtectionListener.java
@@ -1,0 +1,16 @@
+package net.azisaba.lobby.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class FlowerPotProtectionListener implements Listener {
+
+    @EventHandler
+    public void onPot(PlayerInteractEvent e) {
+        Player player = e.getPlayer();
+        if(player.hasPermission("azisabalobby.allow-flower-pot")) return;
+        e.setCancelled(true);
+    }
+}

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -2,6 +2,7 @@ package net.azisaba.lobby.listeners;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Painting;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -10,8 +11,12 @@ public class HangingProtectionListener implements Listener {
 
     @EventHandler
     public void onHanging(EntityDamageByEntityEvent e) {
-        Entity entity = e.getEntity();
-        if (entity instanceof Painting) e.setCancelled(true);
+        Entity damager = e.getDamager();
+        if (damager instanceof Player) {
+            if (damager.hasPermission("azisabalobby.allow-destroy-painting")) return;
+            Entity entity = e.getEntity();
+            if (entity instanceof Painting) e.setCancelled(true);
+        }
     }
 
 }

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -12,7 +12,7 @@ public class HangingProtectionListener implements Listener {
     public void onHanging(EntityDamageByEntityEvent e) {
         Entity damager = e.getDamager();
         if (damager instanceof Player) {
-            if(damager.hasPermission("azisabalobby.allow-picture-frame")) return;
+            if(damager.hasPermission("azisabalobby.allow-destroy-painting")) return;
             e.setCancelled(true);
         }
     }

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -1,6 +1,7 @@
 package net.azisaba.lobby.listeners;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -14,9 +15,9 @@ public class HangingProtectionListener implements Listener {
         Entity damager = e.getDamager();
         if (damager instanceof Player) {
             if (damager.hasPermission("azisabalobby.allow-destroy-painting")) return;
-            Entity entity = e.getEntity();
-            if (entity instanceof Painting) e.setCancelled(true);
         }
+        Entity entity = e.getEntity();
+        if (entity instanceof Painting || entity instanceof ItemFrame) e.setCancelled(true);
     }
 
 }

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -1,6 +1,7 @@
 package net.azisaba.lobby.listeners;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Painting;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,6 +15,8 @@ public class HangingProtectionListener implements Listener {
         if (damager instanceof Player) {
             if(damager.hasPermission("azisabalobby.allow-destroy-painting")) return;
             e.setCancelled(true);
+            Entity entity = e.getEntity();
+            if (entity instanceof Painting) e.setCancelled(true);
         }
     }
 

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -1,0 +1,20 @@
+package net.azisaba.lobby.listeners;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class HangingProtectionListener implements Listener {
+
+    @EventHandler
+    public void onHanging(EntityDamageByEntityEvent e) {
+        Entity damager = e.getDamager();
+        if (damager instanceof Player) {
+            if(damager.hasPermission("azisabalobby.allow-picture-frame")) return;
+            e.setCancelled(true);
+        }
+    }
+
+}

--- a/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
+++ b/src/main/java/net/azisaba/lobby/listeners/HangingProtectionListener.java
@@ -2,7 +2,6 @@ package net.azisaba.lobby.listeners;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Painting;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -11,13 +10,8 @@ public class HangingProtectionListener implements Listener {
 
     @EventHandler
     public void onHanging(EntityDamageByEntityEvent e) {
-        Entity damager = e.getDamager();
-        if (damager instanceof Player) {
-            if(damager.hasPermission("azisabalobby.allow-destroy-painting")) return;
-            e.setCancelled(true);
-            Entity entity = e.getEntity();
-            if (entity instanceof Painting) e.setCancelled(true);
-        }
+        Entity entity = e.getEntity();
+        if (entity instanceof Painting) e.setCancelled(true);
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,9 +5,9 @@ author: siloneco
 description: ${project.description}
 
 permissions:
-  azisabalobby.allow-flower-pot:
+  azisabalobby.allow-interact-flower-pot:
     default: op
     description: 植木鉢の破壊に関するパーミッションです。
-  azisabalobby.allow-picture-frame:
+  azisabalobby.allow-destroy-painting:
     default: op
     description: 額縁の破壊に関するパーミッションです。

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,11 @@ main: net.azisaba.lobby.AzisabaLobby
 version: ${project.version}
 author: siloneco
 description: ${project.description}
+
+permissions:
+  azisabalobby-allow-flower-pot:
+    default: op
+    description: 植木鉢の破壊に関するパーミッションです。
+  azisabalobby-allow-picture-frame:
+    default: op
+    description: 額縁の破壊に関するパーミッションです。

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,9 +5,9 @@ author: siloneco
 description: ${project.description}
 
 permissions:
-  azisabalobby-allow-flower-pot:
+  azisabalobby.allow-flower-pot:
     default: op
     description: 植木鉢の破壊に関するパーミッションです。
-  azisabalobby-allow-picture-frame:
+  azisabalobby.allow-picture-frame:
     default: op
     description: 額縁の破壊に関するパーミッションです。


### PR DESCRIPTION
### description

アジ鯖のロビーで植木鉢・額縁の破壊等の操作を鯖民が出来ないようにします。

### permission

- `azisabalobby-allow-flower-pot`
  - Permissions related to the destruction of flowerpots.
  - default: `op`
- `azisabalobby-allow-picture-frame`
  - Permissions related to the destruction of picture frames.
  - default: `op`